### PR TITLE
Update ConcurrentReadWriteUnorderedHeapFileTest.java

### DIFF
--- a/core/src/test/java/introdb/heap/ConcurrentReadWriteUnorderedHeapFileTest.java
+++ b/core/src/test/java/introdb/heap/ConcurrentReadWriteUnorderedHeapFileTest.java
@@ -1,7 +1,6 @@
 package introdb.heap;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -11,13 +10,10 @@ import java.nio.file.Path;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.AfterEach;
@@ -25,7 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-public class ConcurrentReadWriteUnorderedHeapFileTest {
+class ConcurrentReadWriteUnorderedHeapFileTest {
 
 	private static final Logger LOG = Logger.getLogger("test.readwrite.concurrent");
 
@@ -42,7 +38,7 @@ public class ConcurrentReadWriteUnorderedHeapFileTest {
 	private ExecutorService executors;
 
 	@BeforeEach
-	public void setUp() throws IOException {
+	void setUp() throws IOException {
 		heapFilePath = Files.createTempFile("heap", "0001");
 		heapFile = new UnorderedHeapFile(heapFilePath, MAX_NR_PAGES, PAGE_SIZE);
 
@@ -50,7 +46,7 @@ public class ConcurrentReadWriteUnorderedHeapFileTest {
 	}
 
 	@AfterEach
-	public void tearDown() throws IOException, InterruptedException {
+	void tearDown() throws IOException, InterruptedException {
 		Files.delete(heapFilePath);
 		
 		executors.shutdown();
@@ -60,42 +56,37 @@ public class ConcurrentReadWriteUnorderedHeapFileTest {
 
 	@Test
 	@Tag("slow")
-	public void concurrentReadWrite() throws Exception {
+	void concurrentReadWrite() throws Exception {
 
 		writersLatch = new CountDownLatch(nrOfWriters);		
 		
 		// schedule threads which execute writes to heap file
 		var ws = range(0, nrOfWriters)
 				.mapToObj(writersTasksWith(executors))
-				.collect(toList());
+				.toArray(CompletableFuture[]::new);
 
 		// schedule threads which execute reads to heap file
 		var rs = range(0, nrOfReaders)
 				.mapToObj(readersTasksWith(executors))
-				.collect(toList());
+		        .toArray(CompletableFuture[]::new);
+
 
 		// wait for readers to complete
-		CompletableFuture.allOf(ws.toArray(new CompletableFuture[ws.size()])).get(5,TimeUnit.MINUTES);
+		CompletableFuture.allOf(ws).get(5,TimeUnit.MINUTES);
 
 		// wait for writers to complete
-		CompletableFuture.allOf(rs.toArray(new CompletableFuture[rs.size()])).get(5,TimeUnit.MINUTES);
+		CompletableFuture.allOf(rs).get(5,TimeUnit.MINUTES);
 		
 	}
 
 	private IntFunction<CompletableFuture<Void>> readersTasksWith(ExecutorService executorService) {
-		return (i) -> {
-			return new CompletableFuture<>()
-					.completeAsync(uncheckedFuture(executorService.submit(this::doReads, i)))
-					.thenAccept( r-> LOG.info(format("reader %d is done",r)));
-		};
+		return i -> CompletableFuture.runAsync(this::doReads, executorService)
+				.thenAccept(r-> LOG.info(format("reader %s is done", r)));
 	}
 
 	private IntFunction<CompletableFuture<Void>> writersTasksWith(ExecutorService writers) {
-		return (i) -> {
-			return new CompletableFuture<>()
-					.completeAsync(uncheckedFuture(writers.submit(this::doWrites, i)))
-					.thenAccept( r-> LOG.info(format("writer %d is done",r)));
-		};
+		return i -> CompletableFuture.runAsync(this::doWrites, writers)
+				.thenAccept(r-> LOG.info(format("writer %s is done", r)));
 	}
 
 	private void doReads() {
@@ -111,7 +102,7 @@ public class ConcurrentReadWriteUnorderedHeapFileTest {
 			try {
 				int nextInt = random.nextInt(20);
 				Integer value = (Integer) heapFile.get(nextInt);
-				if (value != null && !value.equals(Integer.valueOf(nextInt))) {
+				if (value != null && !value.equals(nextInt)) {
 					fail("incorrect value read from heap file");
 				}
 			} catch (ClassNotFoundException | IOException e) {
@@ -131,15 +122,5 @@ public class ConcurrentReadWriteUnorderedHeapFileTest {
 				fail(e);
 			}
 		}
-	}
-
-	public <T> Supplier<T> uncheckedFuture(Future<T> future) {
-		return () -> {
-			try {
-				return future.get();
-			} catch (InterruptedException | ExecutionException e) {
-				throw new RuntimeException(e);
-			}
-		};
 	}
 }


### PR DESCRIPTION
1. Just removing redundant `public` modifiers (not obligatory for JUnit 5+)
2. Simplifying `CompletableFuture` usages by leveraging convenience static factory methods
